### PR TITLE
Fix ubuntu version we use in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04", "macos-12", "macos-13"]
+        os: ["ubuntu-24.04", "macos-14", "macos-15"]
         version: ["0.57.0", "latest"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "macos-12", "macos-13"]
+        os: ["ubuntu-24.04", "macos-12", "macos-13"]
         version: ["0.57.0", "latest"]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# Fix ubuntu version we use in tests

## :recycle: Current situation & Problem
Latest SwiftLint binaries seem to build against a newer version of ubuntu. We use that one in tests now.


## :gear: Release Notes 
* Use latest LTS ubuntu.
### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
