### PR TITLE
adjust to new swiftlint naming schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
         shell: bash
         run: |
           mkdir download && cd download
-          wget https://github.com/realm/SwiftLint/releases/latest/download/swiftlint_linux.zip
-          unzip swiftlint_linux.zip
+          wget https://github.com/realm/SwiftLint/releases/latest/download/swiftlint_linux_amd64.zip
+          unzip swiftlint_linux_amd64.zip
           echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
         working-directory: ${{ github.action_path }}
       - name: Print Environment

--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - shell: bash
-      run: echo SL_VERSION=${{ inputs.version }} >> $GITHUB_ENV
     - name: Download SwiftLint
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
         elif [ "${{ runner.os }}" = Linux ]; then
           if [ "${{ inputs.version }}" = "latest" ]; then
             SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/latest/download/swiftlint_linux_amd64.zip"
-          elif [ "${{ inputs.version}}" < "0.60.0" ]; then
+          elif [[ "${{ inputs.version}}" < "0.60.0" ]]; then
             SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${{ inputs.version }}/swiftlint_linux.zip"
           else
             SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${{ inputs.version }}/swiftlint_linux_amd64.zip"

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,6 @@ runs:
     - shell: bash
       run: echo SL_VERSION=${{ inputs.version }} >> $GITHUB_ENV
     - name: Download SwiftLint
-      if: ${{ runner.os == 'macOS' }}
       shell: bash
       run: |
         if [ "${{ runner.os }}" = macOS ]; then

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,9 @@ runs:
           exit 1
         fi
         mkdir download && cd download
-        wget $SWIFTLINT_URL
+        wget -o swiftlint.zip $SWIFTLINT_URL
+        unzip swiftlint.zip
+        echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
       working-directory: ${{ github.action_path }}
     - name: Print Environment
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -31,43 +31,31 @@ runs:
   steps:
     - shell: bash
       run: echo SL_VERSION=${{ inputs.version }} >> $GITHUB_ENV
-    - name: Download SwiftLint latest (macOS)
-      if: ${{ inputs.version == 'latest' && runner.os == 'macOS' }}
+    - name: Download SwiftLint
+      if: ${{ runner.os == 'macOS' }}
       shell: bash
       run: |
+        if [ "${{ runner.os }}" = macOS ]; then
+          if [ "${{ inputs.version }}" = "latest" ]; then
+            SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/latest/download/portable_swiftlint.zip"
+          else
+            SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${{ inputs.version }}/portable_swiftlint.zip"
+          fi
+        elif [ "${{ runner.os }}" = Linux ]; then
+          if [ "${{ inputs.version }}" = "latest" ]; then
+            SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/latest/download/swiftlint_linux_amd64.zip"
+          elif [ "${{ inputs.version}}" < "0.60.0" ]; then
+            SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${{ inputs.version }}/swiftlint_linux.zip"
+          else
+            SWIFTLINT_URL="https://github.com/realm/SwiftLint/releases/download/${{ inputs.version }}/swiftlint_linux_amd64.zip"
+          fi
+        else
+          echo "Unsupported platform ${{ runner.os }}"
+          exit 1
+        fi
         mkdir download && cd download
-        wget https://github.com/realm/SwiftLint/releases/latest/download/portable_swiftlint.zip
-        unzip portable_swiftlint.zip
-        echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
+        wget $SWIFTLINT_URL
       working-directory: ${{ github.action_path }}
-    - name: Download SwiftLint ${{ inputs.version }} (macOS)
-      if: ${{ inputs.version != 'latest' && runner.os == 'macOS' }}
-      shell: bash
-      run: |
-        mkdir download && cd download
-        wget https://github.com/realm/SwiftLint/releases/latest/download/portable_swiftlint.zip
-        unzip portable_swiftlint.zip
-        echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
-      working-directory: ${{ github.action_path }}
-    - name: Download SwiftLint latest (Linux)
-      if: ${{ inputs.version == 'latest' && runner.os == 'Linux' }}
-      shell: bash
-      run: |
-        mkdir download && cd download
-        wget https://github.com/realm/SwiftLint/releases/latest/download/swiftlint_linux_amd64.zip
-        unzip swiftlint_linux_amd64.zip
-        echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
-      working-directory: ${{ github.action_path }}
-    - name: Download SwiftLint ${{ inputs.version }} (Linux)
-      if: ${{ inputs.version != 'latest' && runner.os == 'Linux' }}
-      shell: bash
-      run: |
-        mkdir download && cd download
-        wget https://github.com/realm/SwiftLint/releases/download/${{ env.SL_VERSION }}/swiftlint_linux_amd64.zip
-        unzip swiftlint_linux_amd64.zip
-        echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
-      working-directory: ${{ github.action_path }}
-
     - name: Print Environment
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
           exit 1
         fi
         mkdir download && cd download
-        wget -O swiftlint.zip $SWIFTLINT_URL
+        wget -nv -O swiftlint.zip $SWIFTLINT_URL
         unzip swiftlint.zip
         echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
       working-directory: ${{ github.action_path }}

--- a/action.yml
+++ b/action.yml
@@ -54,8 +54,8 @@ runs:
       shell: bash
       run: |
         mkdir download && cd download
-        wget https://github.com/realm/SwiftLint/releases/latest/download/swiftlint_linux.zip
-        unzip swiftlint_linux.zip
+        wget https://github.com/realm/SwiftLint/releases/latest/download/swiftlint_linux_amd64.zip
+        unzip swiftlint_linux_amd64.zip
         echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
       working-directory: ${{ github.action_path }}
     - name: Download SwiftLint ${{ inputs.version }} (Linux)
@@ -63,8 +63,8 @@ runs:
       shell: bash
       run: |
         mkdir download && cd download
-        wget https://github.com/realm/SwiftLint/releases/download/${{ env.SL_VERSION }}/swiftlint_linux.zip
-        unzip swiftlint_linux.zip
+        wget https://github.com/realm/SwiftLint/releases/download/${{ env.SL_VERSION }}/swiftlint_linux_amd64.zip
+        unzip swiftlint_linux_amd64.zip
         echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
       working-directory: ${{ github.action_path }}
 

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
           exit 1
         fi
         mkdir download && cd download
-        wget -o swiftlint.zip $SWIFTLINT_URL
+        wget -O swiftlint.zip $SWIFTLINT_URL
         unzip swiftlint.zip
         echo SWIFTLINT_BINARY="$(pwd -L)/swiftlint" >> $GITHUB_ENV
       working-directory: ${{ github.action_path }}


### PR DESCRIPTION
# adjust to new swiftlint naming schema

## :recycle: Current situation & Problem
swiftlint 0.60 was released earlier today, which changed the naming schema for the precompiled binaries, causing our CI to fail (bc we always try to pull the latest version by default)


## :gear: Release Notes
- fixed `latest` version handling


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
